### PR TITLE
refactor(font)!: add an explicit assoc type to `IntoOutlines`

### DIFF
--- a/crates/monoxide-font/src/font/glyph/a.rs
+++ b/crates/monoxide-font/src/font/glyph/a.rs
@@ -45,8 +45,10 @@ impl AShape {
 }
 
 impl IntoOutlines for AShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
-        [self.hook.into_outline(), self.bowl.into_outline()].into_iter()
+    type Outlines = [Arc<OutlineExpr>; 2];
+
+    fn into_outlines(self) -> Self::Outlines {
+        [self.hook.into_outline(), self.bowl.into_outline()]
     }
 }
 

--- a/crates/monoxide-font/src/font/glyph/d.rs
+++ b/crates/monoxide-font/src/font/glyph/d.rs
@@ -37,8 +37,10 @@ impl DShape {
 }
 
 impl IntoOutlines for DShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
-        [self.bowl, self.pipe.into_outline()].into_iter()
+    type Outlines = [Arc<OutlineExpr>; 2];
+
+    fn into_outlines(self) -> Self::Outlines {
+        [self.bowl, self.pipe.into_outline()]
     }
 }
 

--- a/crates/monoxide-font/src/font/glyph/e.rs
+++ b/crates/monoxide-font/src/font/glyph/e.rs
@@ -32,8 +32,10 @@ impl EShape {
 }
 
 impl IntoOutlines for EShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
-        [self.bowl.into_outline(), self.bar.into_outline()].into_iter()
+    type Outlines = [Arc<OutlineExpr>; 2];
+
+    fn into_outlines(self) -> Self::Outlines {
+        [self.bowl.into_outline(), self.bar.into_outline()]
     }
 }
 

--- a/crates/monoxide-font/src/font/glyph/f.rs
+++ b/crates/monoxide-font/src/font/glyph/f.rs
@@ -40,9 +40,9 @@ impl FShape {
 }
 
 impl IntoOutlines for FShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
-        [self.hook, self.crossbar]
-            .into_iter()
-            .map(move |it| it.transformed(Affine2D::translated(self.offset)))
+    type Outlines = [Arc<OutlineExpr>; 2];
+
+    fn into_outlines(self) -> Self::Outlines {
+        [self.hook, self.crossbar].map(move |it| it.transformed(Affine2D::translated(self.offset)))
     }
 }

--- a/crates/monoxide-font/src/font/glyph/g.rs
+++ b/crates/monoxide-font/src/font/glyph/g.rs
@@ -36,8 +36,10 @@ impl GShape {
 }
 
 impl IntoOutlines for GShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
-        [self.bowl.into_outline(), self.hook.into_outline()].into_iter()
+    type Outlines = [Arc<OutlineExpr>; 2];
+
+    fn into_outlines(self) -> Self::Outlines {
+        [self.bowl.into_outline(), self.hook.into_outline()]
     }
 }
 

--- a/crates/monoxide-font/src/font/glyph/j.rs
+++ b/crates/monoxide-font/src/font/glyph/j.rs
@@ -68,13 +68,14 @@ impl JShape {
 }
 
 impl IntoOutlines for JShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
+    type Outlines = [Arc<OutlineExpr>; 3];
+
+    fn into_outlines(self) -> Self::Outlines {
         [
             self.hook.into_outline(),
             self.top_serif.into_outline(),
             self.dot.into_outline(),
         ]
-        .into_iter()
         .map(move |it| it.transformed(Affine2D::translated(self.offset)))
     }
 }
@@ -113,9 +114,10 @@ impl JCapShape {
 }
 
 impl IntoOutlines for JCapShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
+    type Outlines = [Arc<OutlineExpr>; 2];
+
+    fn into_outlines(self) -> Self::Outlines {
         [self.hook.into_outline(), self.pipe.into_outline()]
-            .into_iter()
             .map(move |it| it.transformed(Affine2D::translated(self.offset)))
     }
 }

--- a/crates/monoxide-font/src/font/glyph/l.rs
+++ b/crates/monoxide-font/src/font/glyph/l.rs
@@ -32,7 +32,9 @@ impl LShape {
 }
 
 impl IntoOutlines for LShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
+    type Outlines = [Arc<OutlineExpr>; 3];
+
+    fn into_outlines(self) -> Self::Outlines {
         let Self {
             x_range: Range {
                 start: x_min,
@@ -56,8 +58,6 @@ impl IntoOutlines for LShape {
         let bottom_serif =
             Rect::new((mid - hw, y_min), (mid + hw, y_min)).aligned(Alignment::Right);
 
-        [top_serif, pipe, bottom_serif]
-            .into_iter()
-            .map(|it| it.into_outline())
+        [top_serif, pipe, bottom_serif].map(|it| it.into_outline())
     }
 }

--- a/crates/monoxide-font/src/font/glyph/m.rs
+++ b/crates/monoxide-font/src/font/glyph/m.rs
@@ -40,8 +40,11 @@ impl MShape {
 }
 
 impl IntoOutlines for MShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
-        self.hooks.into_outlines().chain([self.pipe.into_outline()])
+    type Outlines = [Arc<OutlineExpr>; 3];
+
+    fn into_outlines(self) -> Self::Outlines {
+        let [h, h1] = self.hooks.map(|it| it.into_outline());
+        [h, h1, self.pipe.into_outline()]
     }
 }
 

--- a/crates/monoxide-font/src/font/glyph/n.rs
+++ b/crates/monoxide-font/src/font/glyph/n.rs
@@ -49,8 +49,10 @@ impl NShape {
 }
 
 impl IntoOutlines for NShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
-        [self.hook.into_outline(), self.pipe.into_outline()].into_iter()
+    type Outlines = [Arc<OutlineExpr>; 2];
+
+    fn into_outlines(self) -> Self::Outlines {
+        [self.hook.into_outline(), self.pipe.into_outline()]
     }
 }
 

--- a/crates/monoxide-font/src/font/glyph/r.rs
+++ b/crates/monoxide-font/src/font/glyph/r.rs
@@ -41,9 +41,10 @@ impl RShape {
 }
 
 impl IntoOutlines for RShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
+    type Outlines = [Arc<OutlineExpr>; 2];
+
+    fn into_outlines(self) -> Self::Outlines {
         [self.hook.into_outline(), self.pipe.into_outline()]
-            .into_iter()
             .map(move |it| it.transformed(Affine2D::translated(self.offset)))
     }
 }

--- a/crates/monoxide-font/src/font/glyph/t.rs
+++ b/crates/monoxide-font/src/font/glyph/t.rs
@@ -39,9 +39,10 @@ impl TShape {
 }
 
 impl IntoOutlines for TShape {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
+    type Outlines = [Arc<OutlineExpr>; 2];
+
+    fn into_outlines(self) -> Self::Outlines {
         [self.hook.into_outline(), self.crossbar.into_outline()]
-            .into_iter()
             .map(move |it| it.transformed(Affine2D::translated(self.offset)))
     }
 }

--- a/crates/monoxide-font/src/font/glyph/w.rs
+++ b/crates/monoxide-font/src/font/glyph/w.rs
@@ -40,7 +40,9 @@ struct Chevron {
 }
 
 impl IntoOutlines for Chevron {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
+    type Outlines = [Arc<OutlineExpr>; 2];
+
+    fn into_outlines(self) -> Self::Outlines {
         let Self {
             x_range: Range {
                 start: sbl,
@@ -67,6 +69,6 @@ impl IntoOutlines for Chevron {
         let backslash =
             SpiroBuilder::open().insts([bot, g4!(sbl, xh).heading(Dir::U).aligned(aln).width(1.1)]);
 
-        [slash, backslash].into_iter().map(|it| it.into_outline())
+        [slash, backslash].map(|it| it.into_outline())
     }
 }

--- a/crates/monoxide-script/src/dsl.rs
+++ b/crates/monoxide-script/src/dsl.rs
@@ -1,9 +1,10 @@
 mod bezier_builder;
 mod spiro_builder;
 
-use std::sync::Arc;
+use std::{iter, sync::Arc};
 
 pub use bezier_builder::{BezierBuilder, BezierInst};
+use itertools::chain;
 use monoxide_curves::{point::Point2D, xform::Affine2D};
 pub use spiro_builder::{SpiroBuilder, SpiroInst, SpiroInstOpts};
 
@@ -85,9 +86,29 @@ pub trait IntoOutlinesExt: IntoOutlines {
             .into_iter()
             .map(move |outline| outline.transformed(xform))
     }
+
+    fn add<U: IntoOutlines>(self, other: U) -> Add<Self, U>
+    where
+        Self: Sized,
+    {
+        Add(self, other)
+    }
 }
 
 impl<T: IntoOutlines> IntoOutlinesExt for T {}
+
+pub struct Add<T, U>(T, U);
+
+impl<T: IntoOutlines, U: IntoOutlines> IntoOutlines for Add<T, U> {
+    type Outlines = iter::Chain<
+        <T::Outlines as IntoIterator>::IntoIter,
+        <U::Outlines as IntoIterator>::IntoIter,
+    >;
+
+    fn into_outlines(self) -> Self::Outlines {
+        chain!(self.0.into_outlines(), self.1.into_outlines())
+    }
+}
 
 #[doc(hidden)]
 #[macro_export]

--- a/crates/monoxide-script/src/dsl.rs
+++ b/crates/monoxide-script/src/dsl.rs
@@ -54,29 +54,35 @@ impl IntoStrokeAlignment for f64 {
 }
 
 pub trait IntoOutlines {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>>;
+    type Outlines: IntoIterator<Item = Arc<OutlineExpr>>;
+
+    fn into_outlines(self) -> Self::Outlines;
 }
 
 impl<I: IntoIterator<Item = Arc<OutlineExpr>>> IntoOutlines for I {
-    fn into_outlines(self) -> impl Iterator<Item = Arc<OutlineExpr>> {
-        self.into_iter()
+    type Outlines = Self;
+
+    fn into_outlines(self) -> Self::Outlines {
+        self
     }
 }
 
 pub trait IntoOutlinesExt: IntoOutlines {
-    fn stroked(self, width: f64) -> impl Iterator<Item = Arc<OutlineExpr>>
+    fn stroked(self, width: f64) -> impl IntoIterator<Item = Arc<OutlineExpr>>
     where
         Self: Sized,
     {
         self.into_outlines()
+            .into_iter()
             .map(move |outline| outline.stroked(width))
     }
 
-    fn transformed(self, xform: Affine2D<Point2D>) -> impl Iterator<Item = Arc<OutlineExpr>>
+    fn transformed(self, xform: Affine2D<Point2D>) -> impl IntoIterator<Item = Arc<OutlineExpr>>
     where
         Self: Sized,
     {
         self.into_outlines()
+            .into_iter()
             .map(move |outline| outline.transformed(xform))
     }
 }


### PR DESCRIPTION
I think it'd be interesting to actually name the `IntoOutlines::Outlines` type even in an indirect way.

Also its bounds have been adjusted from `Outlines: Iterator<_>` to `Outlines: IntoIterator<_>`.

The implementation itself will be easier to write once https://github.com/rust-lang/rust/issues/63063 lands:

```rs
impl IntoOutlines for DShape {
    type Outlines = impl IntoIterator<Item = Arc<OutlineExpr>>;

    fn into_outlines(self) -> Self::Outlines {
        [self.bowl, self.pipe.into_outline()]
    }
}
```