### PR TITLE
feat(font)!: correct error propagation in font generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,6 +1264,7 @@ dependencies = [
 name = "monoxide"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "monoxide-font",
  "monoxide-script",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 readme = "README.md"
 
 [dependencies]
+anyhow.workspace = true
 monoxide-font.workspace = true
 monoxide-script.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/monoxide-font/src/lib.rs
+++ b/crates/monoxide-font/src/lib.rs
@@ -21,7 +21,7 @@ impl InputContext {
     }
 }
 
-pub fn make_font() -> Result<FontContext, ()> {
+pub fn make_font() -> FontContext {
     let cx = InputContext {
         settings: make_font_params(),
     };
@@ -31,7 +31,7 @@ pub fn make_font() -> Result<FontContext, ()> {
         fcx.set_mapping(ch, gl(&cx));
     }
     fcx.set_tofu();
-    Ok(fcx)
+    fcx
 }
 
 pub const fn make_font_params() -> FontParamSettings {

--- a/crates/monoxide-playground/src/lib.rs
+++ b/crates/monoxide-playground/src/lib.rs
@@ -28,9 +28,7 @@ pub enum Subcommand {
 }
 
 impl Playground {
-    pub async fn dispatch<E: Debug>(
-        mut make_font: impl FnMut() -> Result<FontContext, E>,
-    ) -> Result<()> {
+    pub async fn dispatch(mut make_font: impl FnMut() -> FontContext) -> Result<()> {
         tracing_subscriber::fmt()
             .with_env_filter(
                 tracing_subscriber::EnvFilter::from_default_env()
@@ -47,10 +45,7 @@ impl Playground {
 }
 
 impl web::ServerCommand {
-    async fn run<E: Debug>(
-        self,
-        make_font: &mut impl FnMut() -> Result<FontContext, E>,
-    ) -> Result<()> {
+    async fn run(self, make_font: &mut impl FnMut() -> FontContext) -> Result<()> {
         let (tx, rx) = tokio::sync::mpsc::channel::<()>(10);
         let mut rx = std::pin::pin!(tokio_stream::wrappers::ReceiverStream::new(rx));
 
@@ -103,10 +98,7 @@ enum MetaCompressKind {
 }
 
 impl RenderCommand {
-    async fn run<E: Debug>(
-        self,
-        make_font: &mut impl FnMut() -> Result<FontContext, E>,
-    ) -> Result<()> {
+    async fn run(self, make_font: &mut impl FnMut() -> FontContext) -> Result<()> {
         let mut out_dir = self.dir;
         if !out_dir.is_absolute() {
             out_dir = std::env::current_dir()?.join(out_dir);

--- a/crates/monoxide-playground/src/web.rs
+++ b/crates/monoxide-playground/src/web.rs
@@ -9,7 +9,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, bail};
 use axum::{
     Router,
     extract::State,
@@ -106,8 +106,8 @@ pub struct CompiledFont {
 }
 
 impl CompiledFont {
-    pub fn new<E: Debug>(make_font: &mut impl FnMut() -> Result<FontContext, E>) -> Result<Self> {
-        let fcx = make_font().map_err(|e| anyhow!("{e:?}"))?;
+    pub fn new(make_font: &mut impl FnMut() -> FontContext) -> Result<Self> {
+        let fcx = make_font();
         let ser_fcx = layout_glyphs(&fcx)?;
         let metadata = FontMetadata::new(&fcx, ser_fcx);
 

--- a/crates/monoxide-script/src/eval/outline.rs
+++ b/crates/monoxide-script/src/eval/outline.rs
@@ -84,7 +84,9 @@ impl<Id: Copy> EvalValue<Id> {
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum EvalError<Id> {
-    #[error("stroking a bezier is not supported yet; at {0}")]
+    #[error(
+        "bezier stroking unimplemented at {0}: try putting `.transformed()` before `.stroked()`"
+    )]
     StrokingABezier(Id),
 
     #[error("curve evaluation error at {0}: {1}")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,26 @@
-use monoxide_font::make_font;
-use monoxide_script::eval::AuxiliarySettings;
+use std::fs::File;
 
-fn main() {
+use monoxide_font::make_font;
+use monoxide_script::eval;
+use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+
+fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive(tracing_subscriber::filter::LevelFilter::INFO.into()),
-        )
+        .with_env_filter(EnvFilter::from_default_env().add_directive(LevelFilter::INFO.into()))
         .init();
     eprintln!("Hello from Monoxide!");
 
-    let res = monoxide_script::eval::eval(
+    let res = eval::eval(
         &make_font(),
-        &AuxiliarySettings {
+        &eval::AuxiliarySettings {
             point_per_em: 2048,
             font_name: "Monoxide".into(),
         },
-    )
-    .expect("Failed to evaluate font context");
+    )?;
+
     let fout = "out.ttf";
-    res.write(std::fs::File::create(fout).expect("Failed to open file"))
-        .expect("Failed to write font");
+    res.write(File::create(fout)?)?;
     eprintln!("Successfully generated '{fout}'");
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,9 @@ fn main() {
         )
         .init();
     eprintln!("Hello from Monoxide!");
-    let fcx = make_font().expect("Unable to create font");
+
     let res = monoxide_script::eval::eval(
-        &fcx,
+        &make_font(),
         &AuxiliarySettings {
             point_per_em: 2048,
             font_name: "Monoxide".into(),


### PR DESCRIPTION
In response to #93, this output format is long overdue:

```console
> cargo run
   Compiling monoxide v0.1.0 (/work/monoxide)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.30s
     Running `target/debug/monoxide`
Hello from Monoxide!
Error: Failed to layout glyphs

Caused by:
    0: Failed to evaluate glyph, at glyph index 6
    1: bezier stroking unimplemented at (NoId): try putting `.transformed()` before `.stroked()`
```