### PR TITLE
refactor(playground): move `playground` example to tip crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,8 +1265,11 @@ name = "monoxide"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dioxus-devtools",
  "monoxide-font",
+ "monoxide-playground",
  "monoxide-script",
+ "tokio",
  "tracing-subscriber",
 ]
 
@@ -1290,7 +1293,6 @@ dependencies = [
  "dioxus-devtools",
  "itertools 0.15.0",
  "monoxide-curves",
- "monoxide-playground",
  "monoxide-script",
  "monoxide-spiro",
  "snapbox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ monoxide-font.workspace = true
 monoxide-script.workspace = true
 tracing-subscriber.workspace = true
 
-[build-dependencies]
+[dev-dependencies]
+dioxus-devtools.workspace = true
+monoxide-playground.workspace = true
+tokio.workspace = true
 
 [lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }

--- a/crates/monoxide-font/Cargo.toml
+++ b/crates/monoxide-font/Cargo.toml
@@ -7,9 +7,6 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
-[features]
-playground = []
-
 [dependencies]
 monoxide-curves.workspace = true
 monoxide-script.workspace = true
@@ -19,6 +16,5 @@ monoxide-spiro.workspace = true
 anyhow.workspace = true
 dioxus-devtools.workspace = true
 itertools.workspace = true
-monoxide-playground.workspace = true
 snapbox = { workspace = true }
 tokio.workspace = true

--- a/crates/monoxide-font/examples/playground.rs
+++ b/crates/monoxide-font/examples/playground.rs
@@ -1,8 +1,0 @@
-use anyhow::Result;
-use dioxus_devtools::subsecond;
-use monoxide_font::make_font;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    monoxide_playground::Playground::dispatch(|| subsecond::call(make_font)).await
-}

--- a/examples/playground.rs
+++ b/examples/playground.rs
@@ -1,0 +1,8 @@
+use dioxus_devtools::subsecond;
+use monoxide_font::make_font;
+use monoxide_playground::Playground;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    Playground::dispatch(|| subsecond::call(make_font)).await
+}

--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -72,8 +72,6 @@ fn graceful_shutdown(st: &Mutex<ShutdownState>) {
 }
 
 pub fn run(cmd: DevCommand) -> anyhow::Result<()> {
-    let playground_crate = "monoxide-font";
-    let playground_example = "playground";
     let playground_webui_dir = util::playground_webui_dir();
     let playground_webui_dist = util::playground_webui_dist_dir();
 
@@ -122,13 +120,7 @@ pub fn run(cmd: DevCommand) -> anyhow::Result<()> {
     }
 
     // Then start the playground server.
-    let playground_child = start_playground(
-        &cmd,
-        playground_crate,
-        playground_example,
-        webui_port,
-        &playground_webui_dist,
-    )?;
+    let playground_child = start_playground(&cmd, webui_port, &playground_webui_dist)?;
     {
         // graceful shutdown stuff
         let mut st = shutdown_state.lock().unwrap();
@@ -189,8 +181,6 @@ fn check_exit_status(shutdown_state: &Arc<Mutex<ShutdownState>>) -> bool {
 
 fn start_playground(
     cmd: &DevCommand,
-    playground_crate: &str,
-    playground_example: &str,
     webui_port: Option<u16>,
     playground_webui_dir: &Path,
 ) -> anyhow::Result<Child> {
@@ -202,15 +192,7 @@ fn start_playground(
         playground_cmd = Command::new("dx");
         playground_cmd.env("TELEMETRY", "false");
     }
-    playground_cmd.args([
-        "serve",
-        "--hotpatch",
-        "-p",
-        playground_crate,
-        "--example",
-        playground_example,
-        "--features=playground",
-    ]);
+    playground_cmd.args(["serve", "--hotpatch", "--example=playground"]);
     let mut playground_args = vec![Cow::from("serve"), format!("--port={}", cmd.port).into()];
     if let Some(webui_port) = webui_port {
         playground_args.push(format!("--reverse-proxy=http://127.0.0.1:{webui_port}").into());

--- a/xtask/src/ssg.rs
+++ b/xtask/src/ssg.rs
@@ -28,17 +28,7 @@ pub fn run(cmd: SsgCommand) -> anyhow::Result<()> {
     );
 
     let status = Command::new(CARGO)
-        .args([
-            "run",
-            "-p",
-            "monoxide-font",
-            "--features",
-            "playground",
-            "--example",
-            "playground",
-            "--",
-            "render",
-        ])
+        .args(["run", "--example=playground", "--", "render"])
         .arg(&assets_dir)
         .current_dir(workspace_root())
         .stdout(std::process::Stdio::inherit())


### PR DESCRIPTION
Closes #158 by bypassing the issue mentioned in https://github.com/DioxusLabs/dioxus/issues/5540#issuecomment-5150861589.